### PR TITLE
Make GCS bucket configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,10 +152,14 @@ ifeq ($(PROXY_REPO_SHA),)
   export PROXY_REPO_SHA:=$(shell grep PROXY_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')
 endif
 
-# Envoy binary variables Keep the default URLs up-to-date with the latest push from istio/proxy.
 ISTIO_ENVOY_VERSION ?= ${PROXY_REPO_SHA}
-export ISTIO_ENVOY_DEBUG_URL ?= https://storage.googleapis.com/istio-build/proxy/envoy-debug-$(ISTIO_ENVOY_VERSION).tar.gz
-export ISTIO_ENVOY_RELEASE_URL ?= https://storage.googleapis.com/istio-build/proxy/envoy-alpha-$(ISTIO_ENVOY_VERSION).tar.gz
+ifeq ($(ISTIO_BUILD_BUCKET),)
+  ISTIO_BUILD_BUCKET=istio-build
+endif
+# Envoy binary variables Keep the default URLs up-to-date with the latest push from istio/proxy.
+
+export ISTIO_ENVOY_DEBUG_URL ?= https://storage.googleapis.com/${ISTIO_BUILD_BUCKET}/proxy/envoy-debug-$(ISTIO_ENVOY_VERSION).tar.gz
+export ISTIO_ENVOY_RELEASE_URL ?= https://storage.googleapis.com/${ISTIO_BUILD_BUCKET}/proxy/envoy-alpha-$(ISTIO_ENVOY_VERSION).tar.gz
 
 # Use envoy build from local workspace
 export USE_LOCAL_PROXY ?= 0

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -416,7 +416,7 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 			}
 			defer adsc.Close()
 			adsc.Watch()
-			_, err = adsc.Wait("rds", 5*time.Second)
+			_, err = adsc.Wait("rds", 10*time.Second)
 			if err != nil {
 				errChan <- errors.New("failed to get initial rds" + err.Error())
 				wgConnect.Done()


### PR DESCRIPTION
This is needed to download another envoy build than the upstream one